### PR TITLE
Fix IBAMA variable names

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -665,9 +665,9 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL, geo_le
       dataset <- XML::readHTMLTable(tableNode[[1]])
 
 
-      colnames(dataset) <- dataset[6, ]
+      colnames(dataset) <- dataset[5, ]
 
-      dat <- dataset[-c(1:6), ] %>%
+      dat <- dataset[-c(1:5), ] %>%
         janitor::clean_names() %>%
         tibble::as_tibble()
     }

--- a/R/ibama.R
+++ b/R/ibama.R
@@ -75,7 +75,7 @@ load_ibama <- function(dataset = "areas_embargadas",
     legal_amazon_filtered <- legal_amazon %>% dplyr::filter(AMZ_LEGAL == 1)
 
     dat <- dat %>%
-      dplyr::filter(codigo_ibge_municipio_embargo %in% unique(legal_amazon_filtered$CD_MUN))
+      dplyr::filter(municipio_infracao %in% unique(legal_amazon_filtered$NM_MUN))
   }
 
 
@@ -86,8 +86,7 @@ load_ibama <- function(dataset = "areas_embargadas",
   ## Aggregate to municipality-level
   dat <- dat %>%
     dplyr::select(
-      municipio_embargo, uf_embargo,
-      codigo_ibge_municipio_embargo, julgamento,
+      municipio_infracao, uf_infracao, julgamento,
       infracao, data_de_insercao_na_lista,
       cpf_ou_cnpj
     ) %>%
@@ -98,12 +97,10 @@ load_ibama <- function(dataset = "areas_embargadas",
       mes = lubridate::month(data_de_insercao_na_lista)
     ) %>%
     dplyr::rename(
-      municipio = municipio_embargo,
-      uf = uf_embargo,
-      cod_municipio = codigo_ibge_municipio_embargo
+      municipio = municipio_infracao,
+      uf = uf_infracao
     ) %>%
-    dplyr::mutate(cod_municipio = as.numeric(cod_municipio)) %>%
-    dplyr::group_by(cod_municipio, ano, mes) %>%
+    dplyr::group_by(uf, municipio, ano, mes) %>%
     dplyr::summarise(
       n_ja_julgado = sum(!is.na(julgamento), na.rm = TRUE),
       n_infracoes = dplyr::n(),
@@ -111,26 +108,44 @@ load_ibama <- function(dataset = "areas_embargadas",
       .groups = "drop"
     )
 
+  ## Adding IBGE municipality codes
+
+  municipalities <- legal_amazon %>%
+    dplyr::select(municipio = NM_MUN,
+           cod_municipio = CD_MUN)
+
+  dat <- dat %>%
+    dplyr::left_join(municipalities, by = "municipio")
+
+  ## Final variables and translation
+
   if (param$language == 'pt'){
 
     dat_mod = dat %>%
-      dplyr::select(ano, mes, cod_municipio,
+      dplyr::select(ano, mes, uf, municipio, cod_municipio,
                     n_ja_julgado, n_infracoes, n_cpf_cnpj_unicos
       ) %>%
-      dplyr::arrange(ano, mes, cod_municipio)
+      dplyr::arrange(ano, mes, municipio)
 
   }
 
   if (param$language == 'eng'){
 
     dat_mod = dat %>%
-      dplyr::select(year = ano, month = mes, municipality_code = cod_municipio,
+      dplyr::select(year = ano, month = mes, state = uf,
+                    municipality = municipio, municipality_code = cod_municipio,
                     n_already_judged = n_ja_julgado,
                     n_infringement = n_infracoes,
                     n_unique_cpf_cnpj = n_cpf_cnpj_unicos
       ) %>%
-      dplyr::arrange(year, month, municipality_code)
+      dplyr::arrange(year, month, municipality)
 
   }
+
+  ####################
+  ## Returning Data ##
+  ####################
+
+  return(dat_mod)
 
 }


### PR DESCRIPTION
It seems that the [spreadsheets](https://servicos.ibama.gov.br/ctf/publico/areasembargadas/ConsultaPublicaAreasEmbargadas.php) provided by IBAMA had a change in format. They now lack a municipality code variable, contain colnames on a different row, and had a few variable name changes.

As a result, when `legal_amazon_only = TRUE` was chosen,  the line

`dat <- dat %>%
      dplyr::filter(codigo_ibge_municipio_embargo %in% unique(legal_amazon_filtered$CD_MUN))`

was returning an error, as the codigo_ibge variable is not provided anymore. Filtering now goes by the municipality name, which leaves out a few municipalities due to spelling inconsistencies.

When the option `raw_data = FALSE` was set, there was also an error due to the new variable names.