### PR TITLE
Internalizing shapefile

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,5 @@
 ^docs$
 ^pkgdown$
 ^R/zzz$
+^logo\.png$
+^data-raw/geo_municipalities\.rds$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,10 +46,8 @@ URL: http://www.econ.puc-rio.br/datazoom/
 Suggests: 
     knitr,
     rmarkdown,
-    ggplot2,
-    geobr
-Remotes:
-    ipeaGIT/geobr/r-package
+    ggplot2
 VignetteBuilder: knitr
 Depends: 
     R (>= 4.0)
+LazyData: true

--- a/R/degrad.R
+++ b/R/degrad.R
@@ -170,7 +170,7 @@ load_degrad <- function(dataset = 'degrad', raw_data,
 
   # Loading municipal map data
   geo_br <- external_download(dataset = "geo_municipalities",
-                              source = "geobr")
+                              source = "internal")
 
   # legal_amazon belongs to package's sysdata.rda and filters for municipalities in legal amazon
   amazon_municipalities <- dplyr::filter(municipalities, .data$legal_amazon == 1)

--- a/R/degrad.R
+++ b/R/degrad.R
@@ -35,16 +35,6 @@ load_degrad <- function(dataset = 'degrad', raw_data,
                         time_period,
                         language = 'eng') {
 
-  # Checking for geobr package (in Suggests)
-
-  if (!requireNamespace("geobr", quietly = TRUE)) {
-    stop(
-      "Package \"geobr\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
-
   # ,all_events = FALSE
 
   ## To-Do:
@@ -178,12 +168,8 @@ load_degrad <- function(dataset = 'degrad', raw_data,
 
   ## Selecting Municipalities in the Legal Amazon
 
-  # Downloading municipal map from geobr filtered to legl amazon municipalities
-
-  message("Downloading map data.")
-
-  # Downloading municipal map from geobr
-  geo_br <- geobr::read_municipality(year = 2019, simplified = FALSE) # 2019 relates to the definition of legal_amazon
+  # Loading municipal map data
+  geo_br <- geo_municipalities
 
   # legal_amazon belongs to package's sysdata.rda and filters for municipalities in legal amazon
   amazon_municipalities <- dplyr::filter(municipalities, .data$legal_amazon == 1)

--- a/R/degrad.R
+++ b/R/degrad.R
@@ -169,7 +169,8 @@ load_degrad <- function(dataset = 'degrad', raw_data,
   ## Selecting Municipalities in the Legal Amazon
 
   # Loading municipal map data
-  geo_br <- geo_municipalities
+  geo_br <- external_download(dataset = "geo_municipalities",
+                              source = "geobr")
 
   # legal_amazon belongs to package's sysdata.rda and filters for municipalities in legal amazon
   amazon_municipalities <- dplyr::filter(municipalities, .data$legal_amazon == 1)

--- a/R/deter.R
+++ b/R/deter.R
@@ -105,7 +105,7 @@ load_deter <- function(dataset = NULL, raw_data,
 
   # Loading municipal map data
   geo_br <- external_download(dataset = "geo_municipalities",
-                              source = "geobr")
+                              source = "internal")
 
   ###################
   ## Harmonize CRS ##

--- a/R/deter.R
+++ b/R/deter.R
@@ -104,7 +104,8 @@ load_deter <- function(dataset = NULL, raw_data,
   ######################
 
   # Loading municipal map data
-  geo_br <- geo_municipalities
+  geo_br <- external_download(dataset = "geo_municipalities",
+                              source = "geobr")
 
   ###################
   ## Harmonize CRS ##

--- a/R/deter.R
+++ b/R/deter.R
@@ -31,16 +31,6 @@
 load_deter <- function(dataset = NULL, raw_data,
                        language = 'eng') {
 
-  # Checking for geobr package (in Suggests)
-
-  if (!requireNamespace("geobr", quietly = TRUE)) {
-    stop(
-      "Package \"geobr\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
-
   ## Dataset can be either Amazonia or Cerrado
   # Default is all time-periods
 
@@ -112,12 +102,9 @@ load_deter <- function(dataset = NULL, raw_data,
   ######################
   ## Data Engineering ##
   ######################
-  # Downloading municipal map from geobr filtered to legl amazon municipalities
 
-  message("Downloading map data.")
-
-  # Downloading municipal map from geobr
-  geo_br <- geobr::read_municipality(year = 2019, simplified = FALSE)
+  # Loading municipal map data
+  geo_br <- geo_municipalities
 
   ###################
   ## Harmonize CRS ##

--- a/R/download.R
+++ b/R/download.R
@@ -456,7 +456,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL, geo_le
   ## GeoBR Shapefile ##
   #####################
 
-  if (source == "geobr"){
+  if (source == "internal"){
     if (dataset == "geo_municipalities"){
       path <- param$url
     }
@@ -488,7 +488,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL, geo_le
   if (source == "ibama") {
     file_extension <- ".zip"
   }
-  if (source == "geobr"){
+  if (source == "internal"){
     file_extension <- ".rds"
   }
 
@@ -888,7 +888,7 @@ datasets_link <- function() {
 
     ## Shapefile from github repository
 
-    "geobr", "geo_municipalities", NA, "2020", "Municipality", "https://raw.github.com/datazoompuc/datazoom.amazonia/master/data-raw/geo_municipalities.rds"
+    "Internal", "geo_municipalities", NA, "2020", "Municipality", "https://raw.github.com/datazoompuc/datazoom.amazonia/master/data-raw/geo_municipalities.rds"
   )
 
   return(link)

--- a/R/download.R
+++ b/R/download.R
@@ -452,6 +452,16 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL, geo_le
     }
   }
 
+  #####################
+  ## GeoBR Shapefile ##
+  #####################
+
+  if (source == "geobr"){
+    if (dataset == "geo_municipalities"){
+      path <- param$url
+    }
+  }
+
 
   #######################
   ## Initiate Download ##
@@ -477,6 +487,9 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL, geo_le
   }
   if (source == "ibama") {
     file_extension <- ".zip"
+  }
+  if (source == "geobr"){
+    file_extension <- ".rds"
   }
 
   # !!!  We should Change This to a Curl Process
@@ -527,6 +540,9 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL, geo_le
     dat <- readr::read_csv(temp, locale = readr::locale(encoding = "latin1")) %>%
       janitor::clean_names() %>%
       tibble::as_tibble()
+  }
+  if (file_extension == ".rds"){
+    dat <- readr::read_rds(temp)
   }
   if (file_extension == ".xlsx") {
     if (param$dataset == "mapbiomas_cover") {
@@ -869,6 +885,10 @@ datasets_link <- function() {
     ## Demographic Info ##
 
     # https://sidra.ibge.gov.br/pesquisa/censo-demografico/series-temporais/series-temporais/
+
+    ## Shapefile from github repository
+
+    "geobr", "geo_municipalities", NA, "2020", "Municipality", "https://raw.github.com/datazoompuc/datazoom.amazonia/master/data-raw/geo_municipalities.rds"
   )
 
   return(link)

--- a/data-raw/build_sysdata.R
+++ b/data-raw/build_sysdata.R
@@ -2,8 +2,10 @@ library(tidyverse)
 
 ## Importing all municipalities
 
-municipalities <- geobr::read_municipality(year = 2020,
-                                               simplified = FALSE) %>%
+geo_municipalities <- geobr::read_municipality(year = 2020,
+                                               simplified = T)
+
+municipalities <- geo_municipalities %>%
   sf::st_drop_geometry()
 
 ## Importing Legal Amazon municipalities
@@ -42,6 +44,7 @@ municipalities <- municipalities %>%
 
 usethis::use_data(
   municipalities,
+  geo_municipalities,
   internal = TRUE,
   overwrite = TRUE
 )

--- a/data-raw/build_sysdata.R
+++ b/data-raw/build_sysdata.R
@@ -44,7 +44,10 @@ municipalities <- municipalities %>%
 
 usethis::use_data(
   municipalities,
-  geo_municipalities,
   internal = TRUE,
   overwrite = TRUE
 )
+
+## Writing shapefile to /data-raw/
+
+write_rds(geo_municipalities, "./data-raw/geo_municipalities.rds", compress = "bz2")


### PR DESCRIPTION
Instead of relying on geobr directly, "geo_municipalities.rds" is now stored directly in our repo, and loaded with `external_download(source = "internal", dataset = "geo_municipalities")`