### PR TITLE
deter data treatment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: datazoom.amazonia
 Title: Simplify Access to Data from the Amazon Region
-Version: 0.8.1.9000
+Version: 0.8.2.9000
 Authors@R: c(
     person("Francisco", "de Lima Cavalcanti", , "francisco.lima.cavalcanti@gmail.com", role = c("aut", "cre")),
     person("DataZoom (PUC-Rio)", , , "datazoom@econ.puc-rio.br", role = "fnd"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# datazoom.amazonia 0.8.2.9000
+
+  * Adding a sequential identification variable to `load_deter`
+
 # datazoom.amazonia 0.8.1.9000
 
   * Changed code to initiate Deter download

--- a/R/deter.R
+++ b/R/deter.R
@@ -1,3 +1,6 @@
+utils::globalVariables("where") # the selection helper 'where' is not exported from tidyselect, so this must be used to avoid notes
+# they've recently made the move to export it, but it's still not is CRAN
+
 #' @title DETER - Forest Degradation in the Brazilian Amazon
 #'
 #' @description Loads information on change in forest cover in the Amazon. See \url{http://www.obt.inpe.br/OBT/assuntos/programas/amazonia/deter/deter}
@@ -6,7 +9,7 @@
 #' @param raw_data A \code{boolean} setting the return of raw (\code{TRUE}) or processed (\code{FALSE}) data.
 #' @param language A \code{string} that indicates in which language the data will be returned. Currently, only Portuguese ("pt") and English ("eng") are supported. Defaults to "eng".
 #'
-#' @return A \code{tibble} with the selected data.
+#' @return A \code{tibble} (if \code{raw_data} = \code{TRUE}) or a \code{sf} object (if \code{raw_data} = \code{FALSE}).
 #'
 #' @encoding UTF-8
 #'
@@ -38,7 +41,8 @@ load_deter <- function(dataset, raw_data = FALSE,
 
   ## Bind Global Variables
 
-
+  .data <- view_date <- name_muni <- code_muni <- sensor <- satellite <- NULL
+  uc <- classname <- path_row <- area <- quadrant <- geometry <- NULL
 
   #############################
   ## Define Basic Parameters ##
@@ -69,7 +73,6 @@ load_deter <- function(dataset, raw_data = FALSE,
   ######################
 
   dat <- dat %>%
-    janitor::clean_names() %>%
     dplyr::mutate(
       dplyr::across(
         where(is.character),
@@ -129,8 +132,8 @@ load_deter <- function(dataset, raw_data = FALSE,
         "date" = view_date,
         "municipality" = name_muni,
         "municipality_code" = code_muni,
-        class_name = classname,
-        pathrow = path_row
+        "class_name" = classname,
+        "pathrow" = path_row
       )
   }
 

--- a/R/deter.R
+++ b/R/deter.R
@@ -42,7 +42,7 @@ load_deter <- function(dataset, raw_data = FALSE,
   ## Bind Global Variables
 
   .data <- view_date <- name_muni <- code_muni <- sensor <- satellite <- NULL
-  uc <- classname <- path_row <- area <- quadrant <- geometry <- NULL
+  uc <- classname <- path_row <- area <- quadrant <- geometry <- id_alerta <- NULL
 
   #############################
   ## Define Basic Parameters ##
@@ -60,7 +60,7 @@ load_deter <- function(dataset, raw_data = FALSE,
   dat <- external_download(
     dataset = param$dataset,
     source = "deter"
-    )
+  )
 
   ## Return Raw Data
 
@@ -86,6 +86,11 @@ load_deter <- function(dataset, raw_data = FALSE,
     source = "internal"
   )
 
+  # Adding alert_id variable to preserve the information of which rows belong to the same alert
+
+  dat <- dat %>%
+    dplyr::mutate(id_alerta = dplyr::row_number())
+
   ###################
   ## Harmonize CRS ##
   ###################
@@ -106,8 +111,8 @@ load_deter <- function(dataset, raw_data = FALSE,
 
   dat <- dat %>%
     dplyr::select(
-      view_date, name_muni, code_muni, sensor, satellite, uc,
-      classname, path_row, area, quadrant, geometry
+      view_date, name_muni, code_muni, sensor, satellite,
+      classname, path_row, area, quadrant, geometry, id_alerta
     )
 
   ###################
@@ -133,7 +138,7 @@ load_deter <- function(dataset, raw_data = FALSE,
         "municipality" = name_muni,
         "municipality_code" = code_muni,
         "class_name" = classname,
-        "pathrow" = path_row
+        "alert_id" = id_alerta
       )
   }
 

--- a/man/load_deter.Rd
+++ b/man/load_deter.Rd
@@ -5,7 +5,7 @@
 \alias{load_deter}
 \title{DETER - Forest Degradation in the Brazilian Amazon}
 \usage{
-load_deter(dataset = NULL, raw_data, language = "eng")
+load_deter(dataset, raw_data = FALSE, language = "eng")
 }
 \arguments{
 \item{dataset}{A dataset name ("deter_amz", "deter_cerrado") with information about both Amazon and Cerrado}
@@ -15,7 +15,7 @@ load_deter(dataset = NULL, raw_data, language = "eng")
 \item{language}{A \code{string} that indicates in which language the data will be returned. Currently, only Portuguese ("pt") and English ("eng") are supported. Defaults to "eng".}
 }
 \value{
-A \code{tibble} with the selected data.
+A \code{tibble} (if \code{raw_data} = \code{TRUE}) or a \code{sf} object (if \code{raw_data} = \code{FALSE}).
 }
 \description{
 Loads information on change in forest cover in the Amazon. See \url{http://www.obt.inpe.br/OBT/assuntos/programas/amazonia/deter/deter}

--- a/vignettes/DETER.Rmd
+++ b/vignettes/DETER.Rmd
@@ -16,7 +16,9 @@ knitr::opts_chunk$set(
 
 ## The Dataset
 
-DETER uses satellite surveillance to detect and report changes in forest cover across the Legal Amazon and the Cerrado biome. Each data point consists of a warning, describing which type of change has affected a certain area of forest at a given date. Broadly speaking, it makes a distinction between events of deforestation, degradation and logging. The data extracted here spans from 2016 onward in the Amazon, and from 2018 onward in the Cerrado. 
+DETER uses satellite surveillance to detect and report changes in forest cover across the Legal Amazon and the Cerrado biome. Each data point consists of a warning, describing which type of change has affected a certain area of forest at a given date. Broadly speaking, it makes a distinction between events of deforestation, degradation and logging. The data extracted here spans from 2016 onward in the Amazon, and from 2018 onward in the Cerrado.
+
+The raw DETER data shows one warning per row, with each row also containing a municipality. However, many warnings actually overlap with 2 or up to 4 municipalities, which are not shown in the original data. Therefore, when the option `raw_data = TRUE` is selected, the original spatial information is intersected with a municipalities map of Brazil, and each warning can be split into more than one row, with each row corresponding to a municipality.
 
 ## Usage
 
@@ -33,4 +35,3 @@ deter_cer <- load_deter(dataset = 'deter_cerrado',
                         raw_data = FALSE,
                         language = "pt")
 ```
-


### PR DESCRIPTION
Some alerts cross over more than one municipality, resulting in more rows being created when `raw_data = FALSE`. As a quick fix, I added an "alert_id" variable (just a sequential number for each alert) so that you can still tell which rows came from the same alert once the shapefile is intercepted with the municipalities map.

Also removed the "uc" variable when `raw_data = FALSE`, as it seems a bit misleading: it shows the name of the UC which crosses with the alert, but that doesn't mean the whole area of the alert is contained in the UC, so this doesn't really work out for intersecting with municipalities. To tell apart the area contained in the UC, one must use `raw_data = TRUE` (which, as a downside, only reports one municipality per alert when there are sometimes more).

There could be some other ways to improve the final output. Edit: such as adding a `geo_level` argument to choose whether you want UCs or municipalities, but that would require using a shapefile with all the UCs so that the outputs are consistent. For now it makes sense to just focus on municipalities.