### PR TITLE
fixing MAPBIOMAS download

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -403,11 +403,13 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
 
 
   if (source == "mapbiomas") {
-    if (dataset == "mapbiomas_cover") {
-      path <- paste(param$url, "Estat%C3%ADsticas/Cole%C3%A7%C3%A3o%206/1-ESTATISTICAS_MapBiomas_COL6.0_UF-BIOMAS_v12_SITE.xlsx", sep = "")
-    }
-    if (dataset == "mapbiomas_transition") {
-      path <- param$url
+    if (dataset %in% c("mapbiomas_cover", "mapbiomas_transition")) {
+      if (param$geo_level == "state") {
+        path <- paste(param$url, "Estat%C3%ADsticas/Cole%C3%A7%C3%A3o%206/1-ESTATISTICAS_MapBiomas_COL6.0_UF-BIOMAS_v12_SITE.xlsx", sep = "")
+      }
+      if (param$geo_level == "municipality") {
+        path <- "https://drive.google.com/uc?export=download&id=1RT7J2jS6LKyISM49ctfRO31ynJZXX_TY"
+      }
     }
     if (dataset == "mapbiomas_deforestation_regeneration") {
       path <- paste(param$url, "Estat%C3%ADsticas/BD-DESM_e_REG_COL5_V8h__SITE.xlsx", sep = "")
@@ -555,7 +557,16 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
 
   file_extension <- stringr::str_sub(path, -4)
   if (source == "mapbiomas") {
-    file_extension <- ".xlsx"
+    if (dataset %in% c("mapbiomas_cover", "mapbiomas_transition")) {
+      if (param$geo_level == "state") {
+        file_extension <- ".xlsx"
+      }
+      if (param$geo_level == "municipality") {
+        file_extension <- ".zip"
+      }
+    } else {
+      file_extension <- ".xlsx"
+    }
   }
   if (source == "ips") {
     file_extension <- ".xlsx"
@@ -589,7 +600,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   }
   if (source == "iema") {
     file_extension <- ".xlsx"
-  }  
+  }
   if (source == "imazon_shp") {
     file_extension <- ".rds"
   }
@@ -604,7 +615,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   ## Extraction through Curl Requests
   ## Investigate a bit more on how Curl Requests work
 
-  if (source %in% c("comex", "degrad", "internal", "ibama", "ips", "mapbiomas", 'prodes', "sigmine")){
+  if (source %in% c("comex", "degrad", "internal", "ibama", "ips", "prodes", "sigmine")) {
     utils::download.file(url = path, destfile = temp, mode = "wb")
   }
   if (source == "deter") {
@@ -623,18 +634,27 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   if (source %in% c("terraclimate", "ibama")) {
     utils::download.file(url = path, destfile = temp, method = "curl", quiet = TRUE)
   }
-
+  if (source == "mapbiomas") {
+    if (dataset %in% c("mapbiomas_cover", "mapbiomas_transition")) {
+      if (param$geo_level == "state") {
+        utils::download.file(url = path, destfile = temp, mode = "wb")
+      }
+      if (param$geo_level == "municipality") {
+        googledrive::drive_download(path, path = temp, overwrite = TRUE)
+      }
+    } else {
+      utils::download.file(url = path, destfile = temp, mode = "wb")
+    }
+  }
   if (source == "imazon_shp") {
     if (geo_level == "municipality") {
       googledrive::drive_download(path, path = temp, overwrite = TRUE)
     }
   }
-
   if (source == "health") {
     if (stringr::str_detect(dataset, "datasus")) {
       utils::download.file(url = path, destfile = temp, method = "curl", quiet = TRUE)
-    }
-    else{
+    } else {
       utils::download.file(url = path, destfile = temp, mode = "wb")
     }
   }
@@ -774,6 +794,13 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
       dat <- dataset[-c(1:5), ] %>%
         janitor::clean_names() %>%
         tibble::as_tibble()
+    }
+    if (param$source == "mapbiomas") {
+
+      # extracting the one file we care about from the unzipped file
+      file <- list.files(dir, pattern = "1-ESTATISTICAS_MapBiomas_COL6.0_UF-MUNICIPIOS_*", full.names = TRUE)
+
+      dat <- readxl::read_xlsx(file, sheet = param$sheet)
     }
   }
   if (file_extension == ".dbc") {
@@ -994,7 +1021,7 @@ datasets_link <- function() {
     ###############
 
     "MAPBIOMAS", "mapbiomas_cover", NA, "1985-2019", "Municipality, State", "https://mapbiomas-br-site.s3.amazonaws.com/",
-    "MAPBIOMAS", "mapbiomas_transition", NA, "1985-2019", "Municipality, State", "https://storage.googleapis.com/mapbiomas-public/COLECAO/5/DOWNLOADS/ESTATISTICAS/Dados_Transicao_MapBiomas_5.0_UF-MUN_SITE_v2.xlsx",
+    "MAPBIOMAS", "mapbiomas_transition", NA, "1985-2019", "Municipality, State", "https://mapbiomas-br-site.s3.amazonaws.com/",
     "MAPBIOMAS", "mapbiomas_deforestation_regeneration", NA, "1988-2017", "State", "https://mapbiomas-br-site.s3.amazonaws.com/",
     "MAPBIOMAS", "mapbiomas_irrigation", NA, "2000-2019", "State", "https://mapbiomas-br-site.s3.amazonaws.com/",
     "MAPBIOMAS", "mapbiomas_grazing_quality", NA, "2010 & 2018", "State", "https://mapbiomas-br-site.s3.amazonaws.com/",
@@ -1136,11 +1163,11 @@ datasets_link <- function() {
     ## SEEG ##
     ##########
 
-    "SEEG", "seeg_farming", NA, "1970-2019","Country, State, Municipality","http://seeg.eco.br/download",
-    "SEEG", "seeg_industry", NA,"1970-2019","Country, State, Municipality","http://seeg.eco.br/download",
-    "SEEG", "seeg_energy", NA,"1970-2019","Country, State, Municipality","http://seeg.eco.br/download",
-    "SEEG", "seeg_land", NA,"1970-2019","Country, State, Municipality","http://seeg.eco.br/download",
-    "SEEG", "seeg_residuals", NA, "1970-2019","Country, State, Municipality","http://seeg.eco.br/download",
+    "SEEG", "seeg_farming", NA, "1970-2019", "Country, State, Municipality", "http://seeg.eco.br/download",
+    "SEEG", "seeg_industry", NA, "1970-2019", "Country, State, Municipality", "http://seeg.eco.br/download",
+    "SEEG", "seeg_energy", NA, "1970-2019", "Country, State, Municipality", "http://seeg.eco.br/download",
+    "SEEG", "seeg_land", NA, "1970-2019", "Country, State, Municipality", "http://seeg.eco.br/download",
+    "SEEG", "seeg_residuals", NA, "1970-2019", "Country, State, Municipality", "http://seeg.eco.br/download",
 
     ##########
     ## BACI ##
@@ -1156,8 +1183,7 @@ datasets_link <- function() {
     ## IMAZON ##
     ############
     "Imazon", "imazon_shp", NA, "2020", "Municipality", "https://drive.google.com/drive/u/1/folders/1EAOABo1GVKT3YsYkhtgJI9ckB3RULJSC"
-     )
+  )
 
   return(link)
 }
-

--- a/man/load_mapbiomas.Rd
+++ b/man/load_mapbiomas.Rd
@@ -6,26 +6,20 @@
 \usage{
 load_mapbiomas(
   dataset = NULL,
-  raw_data = NULL,
+  raw_data = FALSE,
   geo_level = "municipality",
-  time_period = "all",
   language = "eng",
-  time_id = "year",
   cover_level = 1
 )
 }
 \arguments{
-\item{dataset}{A dataset name ("mapbiomas_cover", "mapbiomas_transition", "mapbiomas_irrigation", "mapbiomas_deforestation_regeneration", "mapbiomas_grazing_quality" or "mapbiomas_mining")}
+\item{dataset}{A dataset name ("mapbiomas_cover", "mapbiomas_transition", "mapbiomas_irrigation", "mapbiomas_deforestation_regeneration", "mapbiomas_grazing_quality", or "mapbiomas_mining")}
 
 \item{raw_data}{A \code{boolean} setting the return of raw or processed data}
 
-\item{geo_level}{A \code{string} that defines the geographic level of the data. Can be only "municipality", except "mapbiomas_mining" which accepts more options ("biome", "indigenous_land")}
-
-\item{time_period}{A \code{numeric} indicating what years will the data be loaded. Can be only "all".}
+\item{geo_level}{A \code{string} that defines the geographic level of the data. For datasets "mapbiomas_cover" and "mapbiomas_transition", can be "municipality" or "state" (faster download) for datasets. For dataset "mapbiomas_mining", can be "biome" or "indigenous_land"}
 
 \item{language}{A \code{string} that indicates in which language the data will be returned. Currently, only Portuguese ("pt") and English ("eng") are supported.}
-
-\item{time_id}{A \code{string} that indicates the time criteria for the data loaded. Can be "year" or "month". Defaults to year.}
 
 \item{cover_level}{A \code{numeric} or \code{string} that indicates the cover aggregation level. Can be "0", "1", "2", "3", "4", or "none", which means no aggregation. Aggregation only supported for "mapbiomas_cover" and "mapbiomas_grazing_quality" datasets.}
 }
@@ -41,7 +35,7 @@ Loads information about land cover and use
 treated_mapbiomas_grazing <- load_mapbiomas(
   dataset = "mapbiomas_grazing_quality",
   raw_data = FALSE, geo_level = "municipality",
-  time_period = "all", language = "pt"
+  language = "pt"
 )
 }
 

--- a/vignettes/MAPBIOMAS.Rmd
+++ b/vignettes/MAPBIOMAS.Rmd
@@ -27,27 +27,27 @@ Using the function is easy enough:
 library(datazoom.amazonia)
 
 # download treated Mapbiomas Cover data in english
-data = load_mapbiomas(dataset = "mapbiomas_cover", raw_data = FALSE, time_period = "all",
+data = load_mapbiomas(dataset = "mapbiomas_cover", raw_data = FALSE, 
                       language = "eng")
 
 # download treated Mapbiomas Transition data in portuguese
-data = load_mapbiomas(dataset = "mapbiomas_transition", raw_data = FALSE, time_period = "all",
+data = load_mapbiomas(dataset = "mapbiomas_transition", raw_data = FALSE,
                       language = "pt")
 
 # download treated Mapbiomas Grazing Quality data in portuguese
-data = load_mapbiomas(dataset = "mapbiomas_grazing_quality", raw_data = FALSE, time_period = "all", language = "pt")
+data = load_mapbiomas(dataset = "mapbiomas_grazing_quality", raw_data = FALSE, language = "pt")
 
 # download treated Mapbiomas Irrigation data in english
 
-data = load_mapbiomas(dataset = "mapbiomas_irrigation", raw_data = FALSE, time_period = "all", language = "eng")
+data = load_mapbiomas(dataset = "mapbiomas_irrigation", raw_data = FALSE,  language = "eng")
 
 # download treated Mapbiomas deforestauon/regeneration data in portuguese
 
-data = load_mapbiomas(dataset = "mapbiomas_deforestation_regeneration", raw_data = FALSE, time_period = 2011, language = "eng")
+data = load_mapbiomas(dataset = "mapbiomas_deforestation_regeneration", raw_data = FALSE, language = "eng")
 
 # download treated country mining data in english
-data = load_mapbiomas(dataset = "mapbiomas_mining", raw_data = FALSE, geo_level = "country", time_period = "all", language = "eng")
+data = load_mapbiomas(dataset = "mapbiomas_mining", raw_data = FALSE, geo_level = "country",  language = "eng")
 
 # download treated biome mining data in english
-data = load_mapbiomas(dataset = "mapbiomas_mining", raw_data = FALSE, geo_level = "biome", time_period = "all", language = "eng")
+data = load_mapbiomas(dataset = "mapbiomas_mining", raw_data = FALSE, geo_level = "biome",  language = "eng")
 ```


### PR DESCRIPTION
When `geo_level = "municipality"`, data for "mapbiomas_transition" and "mapbiomas_cover" are now downloaded from Google Drive. Also removed deprecated parameters `time_period` and `time_id`, which weren't used.