### PR TITLE
simplifying external_download code

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -630,9 +630,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
     googledrive::drive_download(path, path = temp, overwrite = TRUE)
   }
   if (source == "deter") {
-    proc <- RCurl::CFILE(temp, mode = "wb")
-    RCurl::curlPerform(url = path, writedata = proc@ref, noprogress = FALSE)
-    RCurl::close(proc)
+    utils::download.file(url = path, destfile = temp, method = "curl", quiet = FALSE)
   }
   if (source == "seeg") {
     if (geo_level == "state" | geo_level == "country") {

--- a/R/download.R
+++ b/R/download.R
@@ -620,43 +620,42 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   dir <- tempdir()
   temp <- tempfile(fileext = file_extension, tmpdir = dir)
 
-  ## Extraction through Curl Requests
-  ## Investigate a bit more on how Curl Requests work
+  ## Picking the way to download the file
 
-  if (source %in% c("comex", "degrad", "internal", "ips", "prodes", "sigmine")) {
-    utils::download.file(url = path, destfile = temp, mode = "wb")
-  }
+  download_method <- "standard" # works for most functions
+
   if (source %in% c("iema", "imazon_shp")) {
-    googledrive::drive_download(path, path = temp, overwrite = TRUE)
+    download_method <- "googledrive"
   }
-  if (source == "deter") {
-    utils::download.file(url = path, destfile = temp, method = "curl", quiet = FALSE)
-  }
-  if (source == "seeg") {
-    if (geo_level == "state" | geo_level == "country") {
-      utils::download.file(url = path, destfile = temp, mode = "wb")
-    }
-    if (geo_level == "municipality") {
-      googledrive::drive_download(path, path = temp, overwrite = TRUE)
-    }
+  if (source %in% c("deter", "baci")) {
+    download_method <- "curl"
+    quiet <- FALSE
   }
   if (source %in% c("terraclimate", "ibama", "health")) {
-    utils::download.file(url = path, destfile = temp, method = "curl", quiet = TRUE)
+    download_method <- "curl"
+    quiet <- TRUE
   }
-  if (source %in% c("baci")) {
-    utils::download.file(url = path, destfile = temp, method = "curl", quiet = FALSE)
+  if (source == "seeg") {
+    if (geo_level == "municipality") {
+      download_method <- "googledrive"
+    }
   }
   if (source == "mapbiomas") {
-    if (dataset %in% c("mapbiomas_cover", "mapbiomas_transition")) {
-      if (param$geo_level == "state") {
-        utils::download.file(url = path, destfile = temp, mode = "wb")
-      }
-      if (param$geo_level == "municipality") {
-        googledrive::drive_download(path, path = temp, overwrite = TRUE)
-      }
-    } else {
-      utils::download.file(url = path, destfile = temp, mode = "wb")
+    if (dataset %in% c("mapbiomas_cover", "mapbiomas_transition") & param$geo_level == "municipality") {
+      download_method <- "googledrive"
     }
+  }
+
+  ## Downloading file by the selected method
+
+  if (download_method == "standard") {
+    utils::download.file(url = path, destfile = temp, mode = "wb")
+  }
+  if (download_method == "curl") {
+    utils::download.file(url = path, destfile = temp, method = "curl", quiet = quiet)
+  }
+  if (download_method == "googledrive") {
+    googledrive::drive_download(path, path = temp, overwrite = TRUE)
   }
 
   ## This Data Opening Part Should Include the .Shp, not DBF


### PR DESCRIPTION
Instead of, for each function, having a

```
if (source == ...){
download.file(..., mode = "wb")
#or
download.file(..., method = "curl")
#or
drive_download(...)
}
```

we can just use a `download_method` object. By default, it's set by `download_method <- "standard"`, which does the `mode = "wb"`. For functions that require other methods, we basically just have to do

```
if (source == ...){
download_method <- "curl"
#or
download_method <- "googledrive"
}
```

And at the end of everything:
```
if (download_method == "standard"){
 # does the normal "wb" download
}
if (download_method == "curl"){
 # downloads via curl
}
if (download_method == "googledrive"){
 # uses drive_download
}
```

This makes the code quite a bit neater, since a lot of lines were just repeated for many sources.