### PR TITLE
fixing TerraClimate error when `legal_amazon_only = TRUE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: datazoom.amazonia
 Title: Simplify Access to Data from the Amazon Region
-Version: 0.9.1.9000
+Version: 0.9.2.9000
 Authors@R: c(
     person("Francisco", "de Lima Cavalcanti", , "francisco.lima.cavalcanti@gmail.com", role = c("aut", "cre")),
     person("DataZoom (PUC-Rio)", , , "datazoom@econ.puc-rio.br", role = "fnd"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# datazoom.amazonia 0.9.2.9000
+
+  * Fixing `load_climate` error when option `legal_amazon_only = TRUE`
+
 # datazoom.amazonia 0.9.1.9000
 
   * Fixing `load_baci` timeout error upon download

--- a/R/baci.R
+++ b/R/baci.R
@@ -162,6 +162,7 @@ load_baci_dic <- function(language) {
   # Bind Global Variables
 
   locale <- co_sh6 <- co_sh4 <- co_sh2 <- co_ncm_secrom <- no_sh6_ing <- no_sh4_ing <- no_sh2_ing <- no_sec_ing <- NULL
+  no_sh6_por <- product_code <- NULL
 
   #########################
   ## Download Dictionary ##

--- a/R/climate.R
+++ b/R/climate.R
@@ -32,7 +32,7 @@ load_climate <- function(dataset, raw_data = FALSE,
   ## Binding Global Variables ##
   ##############################
 
-  AMZ_LEGAL <- code_muni <- NULL
+  code_muni <- NULL
 
   #############################
   ## Define Basic Parameters ##

--- a/R/climate.R
+++ b/R/climate.R
@@ -45,6 +45,7 @@ load_climate <- function(dataset, raw_data = FALSE,
   param$language <- language
   param$initial_time <- min(time_period)
   param$final_time <- max(time_period)
+  param$legal_amazon_only <- legal_amazon_only
 
   ## Coordinates of rectangle around the Legal Amazon
 
@@ -121,6 +122,7 @@ load_climate <- function(dataset, raw_data = FALSE,
   ## Downloading Data ##
   ######################
 
+  base::message("Downloading TerraClimate data")
 
   dat <- external_download(
     source = "terraclimate",
@@ -153,6 +155,8 @@ load_climate <- function(dataset, raw_data = FALSE,
 
   ## Brazilian municipalities/states/country to merge
 
+  base::message("Downloading Brazilian map data")
+
   map <- external_download(
     dataset = "geo_municipalities",
     source = "internal"
@@ -160,12 +164,12 @@ load_climate <- function(dataset, raw_data = FALSE,
 
   ## Filtering for Legal Amazon
 
-  if (legal_amazon_only) {
-    legal_amazon <- legal_amazon %>%
-      dplyr::filter(AMZ_LEGAL == 1)
+  if (param$legal_amazon_only) {
+    legal_amazon <- datazoom.amazonia::municipalities %>%
+      dplyr::filter(legal_amazon == 1)
 
     map <- map %>%
-      dplyr::filter(code_muni %in% legal_amazon$CD_MUN)
+      dplyr::filter(code_muni %in% legal_amazon$code_muni)
   }
 
   ## Performing merge

--- a/R/download.R
+++ b/R/download.R
@@ -627,11 +627,11 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   if (source %in% c("iema", "imazon_shp")) {
     download_method <- "googledrive"
   }
-  if (source %in% c("deter", "baci")) {
+  if (source %in% c("deter", "terraclimate", "baci")) {
     download_method <- "curl"
     quiet <- FALSE
   }
-  if (source %in% c("terraclimate", "ibama", "health")) {
+  if (source %in% c("ibama", "health")) {
     download_method <- "curl"
     quiet <- TRUE
   }

--- a/man/load_baci.Rd
+++ b/man/load_baci.Rd
@@ -12,7 +12,7 @@ load_baci(dataset = "HS92", raw_data, time_period, language = "pt")
 
 \item{raw_data}{A \code{boolean} setting the return of raw (\code{TRUE}) or processed (\code{FALSE}) data.}
 
-\item{time_period}{A \code{numeric} indicating what years will the data be loaded in the format YYYY. Can be only one year at a time.}
+\item{time_period}{A \code{numeric} indicating for which years the data will be loaded, in the format YYYY. Can be any vector of numbers, such as 2010:2012.}
 
 \item{language}{A \code{string} that indicates in which language the data will be returned. Currently, only Portuguese ("pt") and English ("eng") are supported. Defaults to "pt".}
 }


### PR DESCRIPTION
Function was still using the old `legal_amazon` dataset, so I changed it to `datazoom.amazonia::municipalities`. Also added a couple of `base::message()` to tell the user what's being downloaded and fixed a note I had missed in `load_baci`.