### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/error-report---en.md
+++ b/.github/ISSUE_TEMPLATE/error-report---en.md
@@ -1,0 +1,37 @@
+---
+name: Error report - EN
+about: Report any error message deployed while installing or using our package
+title: Error in <FUNCTION> - <DATASET>
+labels: bug
+assignees: ''
+
+---
+
+## Very brief description of the problem
+
+### Context
+
+Give us some context. Tell us:
+
+- Which dataset were you using when the error occured.
+- If you downloaded the package from github, using DevTools, or directly from CRAN. 
+
+### Code
+
+Please reproduce the exact same code that lead to the error here. It is crucial that this code is a **reprex**, so that we can work on it from our computers. If you are not familiar with the term "reprex", check https://www.tidyverse.org/help/#reprex.
+
+```r
+# insert code here
+```
+
+### Error message and Output
+
+The error message is vital for us to understand what went wrong. Report the output too, if existent.
+
+### Goals and Expectations
+
+Knowing what the users where expecting to receive as output before getting the error message can be really helpful to understand the error and fix it. Write them here, if possible
+
+### Suggestions!
+
+If you have any suggestions to fix the problem, we would be very happy to know! Don´t be ashamed to send it! Overwrite this message with them.

--- a/.github/ISSUE_TEMPLATE/inconvenience-report---en.md
+++ b/.github/ISSUE_TEMPLATE/inconvenience-report---en.md
@@ -1,0 +1,35 @@
+---
+name: Inconvenience report - EN
+about: Report any problem faced while installing or using our package
+title: Inconvenience with <FUNCTION> - <DATASET>
+labels: enhancement
+assignees: ''
+
+---
+
+# Very brief description of the problem
+
+### Warning: This template is destined to report inconveniences or problems of any nature found. However, **errors** itself should be reported using the **"Error report"** template.
+
+### Context
+
+Give us some context. Tell us:
+
+- Which dataset were you using when the problem occured.
+- If you downloaded the package from github, using DevTools, or directly from CRAN. 
+
+### Code
+
+Please reproduce the exact same code that lead to the problem here.  It is vital that this code is a **reprex**, so that we can work on it from our computers. If you are not familiar with the term "reprex", check https://www.tidyverse.org/help/#reprex.
+
+```r
+# insert code here
+```
+
+### Goals and Expectations
+
+Knowing what the users where expecting to receive as output before coming across this problems can be really helpful to understand what went wrong and fix it. Write them here, if possible.
+
+### Suggestions!
+
+If you have any suggestions to fix the problem, we would be very happy to know! Don´t be ashamed to send it! Overwrite this message with them.

--- a/.github/ISSUE_TEMPLATE/relatório-de-erro---pt-br.md
+++ b/.github/ISSUE_TEMPLATE/relatório-de-erro---pt-br.md
@@ -1,0 +1,37 @@
+---
+name: Relatório de erro - PT/BR
+about: Relate qualquer mensagem de erro mostrada enquanto instalava ou usava nosso
+  pacote
+title: Erro em <FUNÇÃO - DATASET>
+labels: bug
+assignees: ''
+
+---
+
+## Descrição sucinta do problema
+
+### Contexto
+
+Nos dê o contexto. Diga:
+
+- Qual dataset estava utilizando quando ocorreu o erro.
+- Se você baixou o pacote pelo GitHub, usando o DevTools, ou diretamente do CRAN.
+
+### Código
+
+Por favor reproduza exatamente o mesmo código que gerou o erro aqui. É crucial que esse código seja um **reprex**, para que possamos trabalhar nele dos nossos computadores. Se você não sabe o que é um "reprex", acesse https://www.tidyverse.org/help/#reprex.
+
+```r
+# insira o código aqui
+```
+### Mensagem de erro e Output
+
+A mensagem de erro é vital para entendermos o que houve de errado. Reporte o Output também, se existente.
+
+### Objetivos e expectativas
+
+Saber onde os usuários estavam esperando chegar quando receberam a mensagem de erro pode ser muito útil para entender qual foi o erro e resolvê-lo. Escreva aqui, se possível.
+
+### Sugestões!
+
+Se você tiver alguma sugestão para resolver o problema, ficaríamos muito felizes de saber. Não se envergonhe de mandar! Escreva por cima dessa mensagem com a(s) mesma(s).

--- a/.github/ISSUE_TEMPLATE/relatório-de-inconveniência---pt-br.md
+++ b/.github/ISSUE_TEMPLATE/relatório-de-inconveniência---pt-br.md
@@ -1,0 +1,35 @@
+---
+name: Relatório de inconveniência - PT/BR
+about: Relate qualquer problema encontrado enquanto instalava ou usava nosso pacote
+title: Inconveniência em <FUNÇÃO> - <DATASET>
+labels: enhancement
+assignees: ''
+
+---
+
+## Descrição sucinta do problema
+
+### Aviso: Esse template é destinado a relatar inconveniências ou problemas de qualquer natureza encontrados. No entanto, **erros** em si devem ser relatados usando o template **"Relatório de erro"**.
+
+### Contexto
+
+Nos dê o contexto. Diga:
+
+- Qual dataset estava utilizando quando ocorreu o problema.
+- Se você baixou o pacote pelo GitHub, usando o DevTools, ou diretamente do CRAN.
+
+### Código
+
+Por favor reproduza exatamente o mesmo código que gerou o problema aqui. É crucial que esse código seja um **reprex**, para que possamos trabalhar nele dos nossos computadores. Se você não sabe o que é um "reprex", acesse https://www.tidyverse.org/help/#reprex.
+
+```r
+# insira o código aqui
+```
+
+### Objetivos e expectativas
+
+Saber onde os usuários estavam esperando chegar quando enfrentaram problemas pode ser muito útil para entender o que houve de errado e resolver. Escreva aqui, se possível.
+
+### Sugestões!
+
+Se você tiver alguma sugestão para resolver o problema, ficaríamos muito felizes de saber. Não se envergonhe de mandar! Escreva por cima dessa mensagem com a(s) mesma(s).


### PR DESCRIPTION
Sugestões para templates de issues, a fim de facilitar o trabalho de identificar os problemas relatados e trabalhar em cima deles. 
São 2 templates com versões em inglês e português, um para erros em si e outro para problemas ou inconveniências encontradas, que não entregam mensagens de erro em si.