### PR TITLE
Population - filtering categories for 2010 download

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -49,10 +49,11 @@ sidra_download <- function(sidra_code = NULL, year, geo_level = "municipality",
   if (param$sidra_code == 6579) {
 
     if (year == 2007) param$sidra_code <- 793  # https://sidra.ibge.gov.br/tabela/793
-    if (year == 2010) {
+    if (year == 2010){
       param$sidra_code <- 1378 # https://sidra.ibge.gov.br/tabela/1378
-      param$classific <- c("c1", "c2", "c287", "c455")
-      param$category <- list(0, 0, 0, 0)
+
+      param$classific <- "c1"
+      param$category <- list(0)
     }
 
   }


### PR DESCRIPTION
For the year 2010 at the state/municipality level, downloading from sidra throws an error:

``` r
Considering all categories once 'classific' was set to 'all' (default)
Error in sidrar::get_sidra(x = param$sidra_code, geo = "State", period = as.character(param$year),  : 
  Quantidade de valores solicitados: 820125 excedeu o limite: 50000
```

Because the data is getting too large, we have to restrict the info we download to only the population number (not age, gender, and condition in the household). When `raw_data = FALSE` we only get the population count anyways. So I modified the edge case for 2010, to download less info.

2007 and all other years seem to be working fine.
