### PR TITLE
IPS - Fixing download

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -552,7 +552,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
 
   download_method <- "standard" # works for most functions
 
-  if (source %in% c("iema", "imazon_shp", "ips")) {
+  if (source %in% c("iema", "imazon_shp")) {
     download_method <- "googledrive"
   }
   if (source == "ANEEL") {
@@ -898,7 +898,7 @@ datasets_link <- function() {
     ## IPS ##
     #########
 
-    "IPS", "ips", NA, "2014 and/or 2018 and/or 2021 and/or 2023", NA, "https://drive.google.com/uc?export=download&id=1ABcLZFraSd6kELHW-pZgpy7ITzs1JagN",
+    "IPS", "ips", NA, "2014 and/or 2018 and/or 2021 and/or 2023", NA, "https://docs.google.com/uc?export=download&id=1ABcLZFraSd6kELHW-pZgpy7ITzs1JagN&format=xlsx",
 
     ###########
     ## IBAMA ##

--- a/R/download.R
+++ b/R/download.R
@@ -507,7 +507,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   if (source == "prodes") {
     file_extension <- ".txt"
   }
-  if (source %in% c("seeg", "iema")) {
+  if (source %in% c("seeg", "iema", "ips")) {
     file_extension <- ".xlsx"
   }
   if (source == "terraclimate") {
@@ -552,7 +552,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
 
   download_method <- "standard" # works for most functions
 
-  if (source %in% c("iema", "imazon_shp")) {
+  if (source %in% c("iema", "imazon_shp", "ips")) {
     download_method <- "googledrive"
   }
   if (source == "ANEEL") {
@@ -898,7 +898,7 @@ datasets_link <- function() {
     ## IPS ##
     #########
 
-    "IPS", "ips", NA, "2014 and/or 2018 and/or 2021 and/or 2023", NA, "https://drive.google.com/drive/folders/1EtSDn9E7BsYmy_toJDVU5UbWcyMDVNGg",
+    "IPS", "ips", NA, "2014 and/or 2018 and/or 2021 and/or 2023", NA, "https://drive.google.com/uc?export=download&id=1ABcLZFraSd6kELHW-pZgpy7ITzs1JagN",
 
     ###########
     ## IBAMA ##

--- a/R/ips.R
+++ b/R/ips.R
@@ -102,10 +102,10 @@ load_ips <- function(dataset = "all", raw_data = FALSE,
   # Picking which sheet to download
 
   sheet_list <- c(
-    "2014" = "IPS 2014",
-    "2018" = "IPS 2018 ",
-    "2021" = "IPS 2021",
-    "2023" = "IPS 2023"
+    "2014" = "2014",
+    "2018" = "2018 ",
+    "2021" = "2021",
+    "2023" = "2023"
   )
 
   sheets <- param$time_period %>%

--- a/R/ips.R
+++ b/R/ips.R
@@ -24,17 +24,6 @@
 load_ips <- function(dataset = "all", raw_data = FALSE,
                      time_period = c(2014, 2018, 2021, 2023), language = "eng") {
 
-  #Checking for googledrive package (in Suggests)
-
-
-  if (!requireNamespace("googledrive", quietly = TRUE)) {
-    stop(
-      "Package \"googledrive\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
-
-
   ###########################
   ## Bind Global Variables ##
   ###########################


### PR DESCRIPTION
As far as I tried, `load_ips` wasn't working at all, as per #201 . It was pretty much just the download link though.

The URL stored in `datasets_link` was [this](https://drive.google.com/drive/folders/1EtSDn9E7BsYmy_toJDVU5UbWcyMDVNGg), which is just the link to the google drive folder. For `external_download` to work, it has to be the link to the file itself.

The procedure is as follows: do "Copy Link" on the file to be downloaded, then pass it through [this website](https://sites.google.com/site/gdocs2direct/) (I just search for "google drive direct link generator" when I need it), to get the actual direct link to the file.

In this particular case, there turns out to be an even better solution. Because the file is small, we can download directly from google sheets, without having to require the `googledrive` package. Just had to find the direct download link from google sheets using `format=xlsx` and paste it in.