### PR TITLE
DETER - fixing file name

### DIFF
--- a/R/deter.R
+++ b/R/deter.R
@@ -1,6 +1,3 @@
-utils::globalVariables("where") # the selection helper 'where' is not exported from tidyselect, so this must be used to avoid notes
-# they've recently made the move to export it, but it's still not is CRAN
-
 #' @title DETER - Forest Degradation in the Brazilian Amazon
 #'
 #' @description Loads information on changes in forest cover in the Amazon.
@@ -62,7 +59,7 @@ load_deter <- function(dataset, raw_data = FALSE,
   dat <- dat %>%
     dplyr::mutate(
       dplyr::across(
-        where(is.character),
+        dplyr::where(is.character),
         ~ stringi::stri_trans_general(., id = "Latin-ASCII")
       )
     )

--- a/R/download.R
+++ b/R/download.R
@@ -618,7 +618,12 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
       dat$year <- param$year
     }
     if (param$source == "deter") {
-      dat <- sf::read_sf(file.path(dir, "deter_public.shp"))
+      if (param$dataset == "deter_amz"){
+        dat <- sf::read_sf(file.path(dir, "deter-amz-deter-public.shp"))
+      }
+      if (param$dataset == "deter_cerrado"){
+        dat <- sf::read_sf(file.path(dir, "deter_public.shp"))
+      }
     }
     if (param$source == "sigmine") {
       dat <- sf::read_sf(file.path(dir, "BRASIL.shp"))


### PR DESCRIPTION
Followed the steps outlined in #196. Also took the chance to remove a bit of old code that was needed at the very top of the function. There used to be some error when trying to use the `where` helper from tidyselect. But now I could just call `dplyr::where`. 