### PR TITLE
DATASUS - fix download error

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -492,7 +492,8 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
 
   # For most functions, the file extension is automatically detected
 
-  file_extension <- sub(".*\\.", ".", path)
+  file_extension <- sub(".*\\.", ".", path) %>%
+    tolower()
 
   ##### Exceptions only #####
 


### PR DESCRIPTION
There was an extremely small mistake in the `download.R` code for DATASUS.

The DATASUS files are named things like `DOAM2010.DBC`. And we define the `file_extension` via `file_extension <- sub(".*\\.", ".", path)`, which returns `".DBC"`.

And the code to actually read the data is
```
if (file_extension == ".dbc") {
      dat <- read.dbc(temp)
}
```

But the `file_extension` wasn't `".dbc"`, it was `".DBC"`, so it just wasn't read, and the `dat` object didn't exist.

All I had to do to fix it was

```
file_extension <- sub(".*\\.", ".", path) %>%
    tolower()
```

to make all file extensions lowercase.