### PR TITLE
Update download.R to include new BACI link

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: datazoom.amazonia
 Title: Simplify Access to Data from the Amazon Region
-Version: 1.1.0.9000
+Version: 1.1.1.9000
 Authors@R: c(
     person("Igor", "Rigolon Veiga", , "igor.rilave@hotmail.com", role = c("aut", "cre")),
     person("DataZoom (PUC-Rio)", , , "datazoom@econ.puc-rio.br", role = "fnd"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# datazoom.amazonia 1.1.1.9000
+
+  * Updated `load_baci` to support the newest version of the data, fixing the previous broken download URL. (Thanks to @OlivazShai)
+
 # datazoom.amazonia 1.1.0.9000 (development version)
 
   * Updated `load_prodes` data cleaning and download to allow more recent data

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -60,7 +60,7 @@ check_params <- function(param) {
     if (!all(param$time_period %in% supp_time_period)) {
       time_period_error <- paste("Option time_period must be in", supp_time_period_str)
 
-      stop(time_period_error)
+      warning(time_period_error)
     }
   }
 

--- a/R/download.R
+++ b/R/download.R
@@ -817,8 +817,8 @@ datasets_link <- function(source = NULL, dataset = NULL, url = FALSE) {
 
     ## BACI
 
-    "baci", "HS92", NA, "1995-2020", "Country", "https://www.cepii.fr/DATA_DOWNLOAD/baci/data/baci_HS92_V202401b.zip",
-                                                
+    "baci", "HS92", NA, "1995-2022", "Country", "https://www.cepii.fr/DATA_DOWNLOAD/baci/data/baci_HS92_V202401b.zip",
+
     ## PIB-Munic
 
     "pibmunic", "pibmunic", "5938", "2002-2020", "Country, State, Municipality", "https://sidra.ibge.gov.br/pesquisa/pib-munic/tabelas",

--- a/R/download.R
+++ b/R/download.R
@@ -584,10 +584,10 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
     }
 
     if (param$source == "baci") {
-      # as year can be a vector, sets up expressions of the form "*YYYY_V202201.csv" for each year to match file names
-      file_expression <- paste0("*", param$year, "_V202201.csv")
+      # as year can be a vector, sets up expressions of the form "*YYYY_V202401b.csv" for each year to match file names
+      file_expression <- paste0("*", param$year, "_V202401b.csv")
 
-      # now turning into *XXXX_V202201.csv|YYYY_V202201.csv|ZZZZ_V202201.csv" to match as regex
+      # now turning into *XXXX_V202401b.csv|YYYY_V202401b.csv|ZZZZ_V202401b.csv" to match as regex
       file_expression <- paste0(file_expression, collapse = "|")
 
       file <- list.files(dir, pattern = file_expression, full.names = TRUE) %>%
@@ -817,8 +817,8 @@ datasets_link <- function(source = NULL, dataset = NULL, url = FALSE) {
 
     ## BACI
 
-    "baci", "HS92", NA, "1995-2020", "Country", "http://www.cepii.fr/DATA_DOWNLOAD/baci/data/baci_HS92_V202201.zip",
-
+    "baci", "HS92", NA, "1995-2020", "Country", "https://www.cepii.fr/DATA_DOWNLOAD/baci/data/baci_HS92_V202401b.zip",
+                                                
     ## PIB-Munic
 
     "pibmunic", "pibmunic", "5938", "2002-2020", "Country, State, Municipality", "https://sidra.ibge.gov.br/pesquisa/pib-munic/tabelas",


### PR DESCRIPTION
All references to the older **V202201** version of the BACI dataset are changed to the most up to date version, the **V202401b**. 

The older version is unavailable, and the original link is broken. I updated the link in line 820 and the regex in line 588. I'm also opening an issue with further explanations. 