### PR TITLE
Update download.R to allow year vectors for baci data

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -338,17 +338,19 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   # Some URLs are in the form www.data/$year$_$dataset$.csv, where expression
   # surrounded by $ are placeholders. The code below subs them in for actual parameters
 
-  if (!is.null(param$year)) {
-    path <- path %>%
-      stringr::str_replace("\\$year\\$", as.character(param$year))
-  }
-  if (!is.null(param$state)) {
-    path <- path %>%
-      stringr::str_replace("\\$state\\$", param$state)
-  }
-  if (!is.null(param$file_name)) {
-    path <- path %>%
-      stringr::str_replace("\\$file_name\\$", param$file_name)
+  if (stringr::str_detect(path, "\\$year\\$|\\$state\\$|\\$file_name\\$")) {
+    if (!is.null(param$year)) {
+      path <- path %>%
+        stringr::str_replace("\\$year\\$", as.character(param$year))
+    }
+    if (!is.null(param$state)) {
+      path <- path %>%
+        stringr::str_replace("\\$state\\$", param$state)
+    }
+    if (!is.null(param$file_name)) {
+      path <- path %>%
+        stringr::str_replace("\\$file_name\\$", param$file_name)
+    }
   }
 
   # Below are the exceptions, for which manipulation is needed
@@ -417,18 +419,6 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
       "&timeStride=1",
       "&disableProjSubset=on&addLatLon=true&accept=netcdf"
     )
-  }
-
-  ## BACI
-
-  # BACI data demands 'param$year' for cleaning, but data is downloaded from 
-  # a single url. If param$year is a vector, the code above would incorrectly 
-  # save 'path' as a vector of urls, failing the download.
-
-  # This exception ensures 'path' is the single url in 'param$url' for baci
-
-  if (source == "baci") {
-    path <- param$url
   }
 
   #######################

--- a/R/download.R
+++ b/R/download.R
@@ -419,6 +419,18 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
     )
   }
 
+  ## BACI
+
+  # BACI data demands 'param$year' for cleaning, but data is downloaded from 
+  # a single url. If param$year is a vector, the code above would incorrectly 
+  # save 'path' as a vector of urls, failing the download.
+
+  # This exception ensures 'path' is the single url in 'param$url' for baci
+
+  if (source == "baci") {
+    path <- param$url
+  }
+
   #######################
   ## Initiate Download ##
   #######################


### PR DESCRIPTION
## Description of the bug

While downloading BACI data for single years is functional, downloding data from a vector of years raises errors. Say, seting `year = 1995:2022` to download the entire series. The result is the following:

```
Error in utils::download.file(url = path, destfile = temp, method = "curl",  : 
 	 'url' must be a length-one character vector
```

## Causes
 
The `year `parameter is used both for data cleaning and for downloading from the sources, when data for each year has a different url. But for Baci data, download is done from a single url, so we don’t need to generate a path for each year.

The download path is first defined as:
```	 
path <- param$url
```

Which would work. But, to account for sources with different urls by year, we have:

```
if (!is.null(param$year)) {
    path <- path %>%
      stringr::str_replace("\\$year\\$", as.character(param$year))
  }
```

If the user-provided `year ` is a one-length vector or NULL, nothing changes and the download proceeds. But if we have an n-length vector, `path` also becomes a vector, with n repetitions of the url.

Then the download operation below raises the error I presented in the beginning:

```
if (download_method == "curl") {
    utils::download.file(url = path, destfile = temp, method = "curl", quiet = quiet)
  }
```

## Workaround year = NULL fails

The possible workaround of doing `year = NULL` downloads everything to `dat`, including files “country_codes_V202401b” and “product_codes_HS92_V202401b”, since the regex only has the term “V202401b” now.

So `rbindlist()` in `baci.R` fails, returning:

```
Error in data.table::rbindlist(.) : 
  Item 29 has 4 columns, inconsistent with item 1 which has 6 columns. To fill missing columns use fill=TRUE.
```

## Solution

I added a new (simple) exception to the definition of the download path in `external_download`. It ensures  'path' is the single url in 'param$url' when sourcing baci files.
