### PR TITLE
Fix different CRS problem

### DIFF
--- a/R/degrad.R
+++ b/R/degrad.R
@@ -93,25 +93,16 @@ load_degrad <- function(dataset = "degrad", raw_data = FALSE,
     return(dat)
   }
 
-  # Join all tables
-  temp <- tibble::tribble(
-    ~linkcolumn, ~scene_id, ~class_name, ~pathrow, ~uf,
-    ~area, ~geometry, ~year, ~con_ai_id, ~julday,
-    ~ano, ~objet_id_3, ~cell_oid, ~view_date,
-    ~codigouf, ~nome, ~inter_oid, ~areametros, ~areameters
-  )
+  # Join all tables while preserving sf objects
+  dat <- do.call(rbind, dat)
 
-  dat <- c(dat, list(temp)) %>%
-    dplyr::bind_rows() %>%
-    tibble::as_tibble()
-
-  # Remove useless columns
+  # Remove useless column
   dat <- dat %>%
-    dplyr::select(-ano, -nome)
+    dplyr::select(-nome)
 
   # Add sigla UF
   ufs <- tibble::tribble(
-    ~sigla, ~codigouf,
+    ~uf, ~codigouf,
     "AC", 12,
     "AL", 27,
     "AP", 16,
@@ -145,9 +136,7 @@ load_degrad <- function(dataset = "degrad", raw_data = FALSE,
   dat <- dat %>%
     dplyr::mutate(codigouf = as.numeric(codigouf)) %>%
     dplyr::left_join(ufs, by = "codigouf") %>%
-    dplyr::mutate(uf = ifelse(is.na(uf), sigla, uf)) %>%
-    dplyr::select(-codigouf, -sigla) %>%
-    dplyr::select(-area, -areametros, -areameters)
+    dplyr::select(-codigouf, -area)
 
 
   # Clean geometry


### PR DESCRIPTION
Problematic lines were last edited in PR #101.
bind_rows() removes sf objects. I tried multiple things, but removing this actually made the code more efficient.

There is A LOT to change in this function. It currently looks very inefficient: inclusiding variables just to get rid of them later. This is just a note on something to improva later on. It is not currently our priority.

Some of the intermediary functions (specially from sf) throw warnings and notes - just FYI in case this is problem for CRAN submission.
Also, I am not 100% sure I didn't accidently remove anything from the final product. Remember this if anyone complains later

This PR resolves #283 
@bernardo-sieira, when reviewing, please actually run devtools::load_all() and run the example to make sure it is working.