### PR TITLE
epe example added

### DIFF
--- a/R/epe.R
+++ b/R/epe.R
@@ -6,6 +6,24 @@
 #' @param geo_level Geographical level: "state" or "subsystem". Only applies to consumer or industrial datasets.
 #' @inheritParams load_baci
 #'
+#' @examples
+#' \dontrun{
+#' # download treated (raw_data = FALSE) data about
+#' # consumer energy consumption (dataset = "consumer_energy_consumption")
+#' # at the state level (geo_level = "state")
+#' data <- load_epe(
+#'   dataset = "consumer_energy_consumption",
+#'   geo_level = "state",
+#'   raw_data = FALSE
+#' )
+#' # download treated (raw_data = FALSE) data
+#' # from the National Energy Balance (dataset = "national_energy_balance")
+#' balance <- load_epe(
+#'   dataset = "national_energy_balance",
+#'   raw_data = FALSE
+#' )
+#' }
+#'
 #' @export
 load_epe <- function(dataset, geo_level = "state", raw_data = FALSE, language = "eng") {
   ##############################

--- a/man/load_epe.Rd
+++ b/man/load_epe.Rd
@@ -18,3 +18,22 @@ load_epe(dataset, geo_level = "state", raw_data = FALSE, language = "eng")
 \description{
 Electrical Energy Monthly Consumption per Class or Industrial Sector
 }
+\examples{
+\dontrun{
+# download treated (raw_data = FALSE) data about
+# consumer energy consumption (dataset = "consumer_energy_consumption")
+# at the state level (geo_level = "state")
+data <- load_epe(
+  dataset = "consumer_energy_consumption",
+  geo_level = "state",
+  raw_data = FALSE
+)
+# download treated (raw_data = FALSE) data
+# from the National Energy Balance (dataset = "national_energy_balance")
+balance <- load_epe(
+  dataset = "national_energy_balance",
+  raw_data = FALSE
+)
+}
+
+}


### PR DESCRIPTION
1. Resolvida a falta de example (usados os mesmos da vignette)
2. Constatado que não há a opção time_period na função, que, após pesquisa, parece explicado pela maneira de download dos outros 2 datasets que não o consumer, sendo num unico arquivo.