### PR TITLE
Fix load_seeg()

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -521,7 +521,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   }
   if (download_method == "googledrive") {
     message("Please follow the steps from `googledrive` package to download the data. This may take a while.\nIn case of authentication errors, run vignette(\"GOOGLEDRIVE\").")
-
+    if (source == "seeg") {googledrive::drive_deauth()}
     googledrive::drive_download(path, path = temp, overwrite = TRUE)
   }
 


### PR DESCRIPTION
Corrige o problema de autenticação da função load_seeg. Com a função googledrive::drive_deauth() o usuário não deve precisar fazer login com a sua conta Google. 
Obs: caso o usuário escolha qualquer geo_level diferente de "municipality", a função ainda retorna erro pois não incorporamos as tabelas dos outros níveis geográficos 