### PR TITLE
Fix load_prodes

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -496,6 +496,11 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
       options(timeout = 1000) # increase timeout limit
     }
   }
+  if (source == "prodes") {
+    message("This may take a while.\n")
+    a <- TRUE
+    options(timeout = max(1000, getOption("timeout")))
+  }
   if (source %in% c("deter", "terraclimate", "baci", "sigmine", "mapbiomas")) {
     download_method <- "curl"
     quiet <- FALSE


### PR DESCRIPTION
Increases timeout limit. The problem was that the prodes dataset file is large (130 mb) so its download exceeded the 60 seconds timeout limit.