### PR TITLE
Remove municipality that is not in the Legal Amazon

### DIFF
--- a/R/prodes.R
+++ b/R/prodes.R
@@ -184,6 +184,11 @@ load_prodes <- function(dataset = "deforestation", raw_data = FALSE,
   dat <- dat %>%
     dplyr::bind_rows()
 
+  # remove exceding municipality
+  ## Passagem Franca (MA) is at 43.95o west, thus mistakenly included through the 44o west rule
+  dat <- dat %>%
+    dplyr::filter(name_muni != "Passagem Franca")
+
   ################################
   ## Harmonizing Variable Names ##
   ################################


### PR DESCRIPTION
Passagem Franca (MA) is at 43.95o west. The rule for inclusion in the Legal Amazon is 44o west. Thus, it was mistaknely included by our outside source due to approximation errors.