### PR TITLE
Aneel new download for energy_development_budget 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,5 +58,5 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 BugReports: https://github.com/datazoompuc/datazoom.amazonia/issues

--- a/R/aneel.R
+++ b/R/aneel.R
@@ -56,16 +56,34 @@ load_aneel <- function(dataset,
   ## Downloading ##
   #################
 
-  dat <- external_download(
-    source = param$source,
-    dataset = param$dataset,
-    year = param$year,
-    skip_rows = skip
-  )
-
+  if (param$dataset == "energy_development_budget" && length(param$year) > 1) {
+    dat <- purrr::map_dfr(param$year, function(y) {
+      df_y <- external_download(
+        source = param$source,
+        dataset = param$dataset,
+        year = y,
+        skip_rows = skip
+      )
+      
+      if (!"year" %in% names(df_y)) {
+        df_y$year <- y
+      }
+      
+      df_y
+    })
+  } else {
+    dat <- external_download(
+      source = param$source,
+      dataset = param$dataset,
+      year = param$year,
+      skip_rows = skip
+    )
+  }
+  
   if (param$raw_data) {
     return(dat)
   }
+  
 
   ######################
   ## Data Engineering ##

--- a/R/aneel.R
+++ b/R/aneel.R
@@ -16,7 +16,10 @@
 #'
 #' @export
 
-load_aneel <- function(dataset, raw_data = FALSE, language = "eng") {
+load_aneel <- function(dataset,
+                       raw_data = FALSE,
+                       language = "eng",
+                       year = NULL) {
   ###########################
   ## Bind Global Variables ##
   ###########################
@@ -32,9 +35,14 @@ load_aneel <- function(dataset, raw_data = FALSE, language = "eng") {
   param$dataset <- dataset
   param$raw_data <- raw_data
   param$language <- language
+  param$year <- year
 
   skip <- NULL
 
+  if (param$dataset == "energy_development_budget" && is.null(param$year)) {
+    stop("For 'energy_development_budget', you must provide 'year'.")
+  }
+  
   if (param$dataset == "energy_generation") {
     skip <- 1
     # skips first row of excel sheet for this dataset
@@ -51,6 +59,7 @@ load_aneel <- function(dataset, raw_data = FALSE, language = "eng") {
   dat <- external_download(
     source = param$source,
     dataset = param$dataset,
+    year = param$year,
     skip_rows = skip
   )
 

--- a/R/aneel.R
+++ b/R/aneel.R
@@ -88,6 +88,12 @@ load_aneel <- function(dataset,
       year = param$year,
       skip_rows = skip
     )
+
+    if (param$dataset == "energy_development_budget" &&
+        !"year" %in% names(dat) &&
+        !"ano" %in% names(dat)) {
+      dat$year <- param$year
+    }
   }
 
   if (param$raw_data) {

--- a/R/aneel.R
+++ b/R/aneel.R
@@ -49,9 +49,21 @@ load_aneel <- function(dataset,
 
   skip <- NULL
 
-  if (param$dataset == "energy_development_budget" && is.null(param$year)) {
+if (param$dataset == "energy_development_budget") {
+  if (is.null(param$year) || length(param$year) == 0) {
     stop("For 'energy_development_budget', you must provide 'year'.")
   }
+
+  invalid_years <- setdiff(as.integer(param$year), 2017:2022)
+
+  if (length(invalid_years) > 0) {
+    stop(
+      "Year(s) not available for 'energy_development_budget': ",
+      paste(invalid_years, collapse = ", "),
+      ". Valid years: 2017-2022."
+    )
+  }
+}
 
   if (param$dataset == "energy_generation") {
     skip <- 1

--- a/R/aneel.R
+++ b/R/aneel.R
@@ -3,6 +3,9 @@
 #' @description National Electric Energy Agency - ANEEL
 #'
 #' @param dataset A dataset name ("energy_development_budget", "energy_generation" or "energy_enterprises_distributed")
+#' @param year A numeric value or vector of years (2017-2022).
+#'   Required for the "energy_development_budget" dataset.
+#'   Ignored for the other datasets.
 #' @inheritParams load_baci
 #'
 #' @examples
@@ -11,6 +14,13 @@
 #' clean_aneel <- load_aneel(
 #'   dataset = "energy_generation",
 #'   raw_data = FALSE
+#' )
+#'
+#' # download raw annual CDE budget data
+#' raw_cde <- load_aneel(
+#'   dataset = "energy_development_budget",
+#'   year = 2021,
+#'   raw_data = TRUE
 #' )
 #' }
 #'
@@ -42,7 +52,7 @@ load_aneel <- function(dataset,
   if (param$dataset == "energy_development_budget" && is.null(param$year)) {
     stop("For 'energy_development_budget', you must provide 'year'.")
   }
-  
+
   if (param$dataset == "energy_generation") {
     skip <- 1
     # skips first row of excel sheet for this dataset
@@ -64,11 +74,11 @@ load_aneel <- function(dataset,
         year = y,
         skip_rows = skip
       )
-      
+
       if (!"year" %in% names(df_y)) {
         df_y$year <- y
       }
-      
+
       df_y
     })
   } else {
@@ -79,11 +89,11 @@ load_aneel <- function(dataset,
       skip_rows = skip
     )
   }
-  
+
   if (param$raw_data) {
     return(dat)
   }
-  
+
 
   ######################
   ## Data Engineering ##

--- a/R/download.R
+++ b/R/download.R
@@ -333,7 +333,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
 
   path <- param$url
 
-  
+
   if (identical(path, "aneel_cde_$year$")) {
     cde_urls <- c(
       "2017" = "https://dadosabertos.aneel.gov.br/dataset/a7191647-b187-4893-b20a-8954d57ff89c/resource/684a68fd-4278-4af1-bcf2-c02810dd7c0c/download/cde-beneficiarios-rede-basica-2017.csv",
@@ -343,18 +343,18 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
       "2021" = "https://dadosabertos.aneel.gov.br/dataset/a7191647-b187-4893-b20a-8954d57ff89c/resource/cdf1b068-7c76-462a-ab57-d6619ad290fa/download/cde-beneficiarios-rede-basica-2021.csv",
       "2022" = "https://dadosabertos.aneel.gov.br/dataset/a7191647-b187-4893-b20a-8954d57ff89c/resource/e390baae-5304-4a94-854f-0905094b3357/download/cde-beneficiarios-rede-basica-2022.csv"
     )
-    
+
     if (is.null(param$year)) {
       stop("For 'energy_development_budget', please provide 'year'.")
     }
-    
+
     if (!as.character(param$year) %in% names(cde_urls)) {
       stop("Year not available for 'energy_development_budget'.")
     }
-    
+
     path <- unname(cde_urls[as.character(param$year)])
   }
-  
+
   ## Filling in URLs
 
   # Some URLs are in the form www.data/$year$_$dataset$.csv, where expression
@@ -593,25 +593,25 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
       file_expression <- paste0("*", param$year, "_V202401b.csv")
       # now turning into *XXXX_V202401b.csv|YYYY_V202401b.csv|ZZZZ_V202401b.csv" to match as regex
       file_expression <- paste0(file_expression, collapse = "|")
-      
+
       file <- list.files(dir, pattern = file_expression, full.names = TRUE) %>%
         as.list()
-      
+
       # now reads each file
-      
+
       dat <- lapply(file, data.table::fread, header = TRUE, sep = ",")
-      
+
       # each data frame in the list is named after the corresponding year
       names(dat) <- param$year
     }
     if (param$source == "prodes") {
       # clearing rasters to avoid overlap
-      
+
       terra::tmpFiles(remove = TRUE)
       file <- list.files(dir, pattern = "*.tif", full.names = TRUE)
       dat <- terra::rast(file)
     }
-    
+
   } else if (param$source == "aneel") {
     if (param$dataset %in% c("energy_enterprises_distributed", "energy_development_budget")) {
       dat <- data.table::fread(temp, encoding = "Latin-1")
@@ -623,23 +623,23 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
         na = c("-", "")
       )
     }
-    
+
   } else if (param$source == "ips") {
     dat <- param$sheet %>%
       purrr::map(
         ~ readxl::read_xlsx(temp, sheet = .)
       )
-    
+
   } else if (param$source == "epe") {
     dat <- param$sheet %>%
       purrr::map(
         ~ base::suppressMessages(readxl::read_xlsx(temp, sheet = .))
       )
-    
+
     ## Now the rest of the functions
-    
+
     # This Depends on Data Type (.csv, .shp, ...) and on the data source
-    
+
   } else {
     if (file_extension == ".csv") {
       dat <- data.table::fread(temp)
@@ -657,7 +657,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
       dat <- readxl::read_xlsx(temp, sheet = param$sheet, skip = param$skip_rows)
     }
   }
-  
+
 
 
 
@@ -920,7 +920,7 @@ datasets_link <- function(source = NULL, dataset = NULL, url = FALSE) {
 
     ## ANEEL
 
-    "aneel", "energy_development_budget", NA, "2013-2022", NA, "aneel_cde_$year$",
+    "aneel", "energy_development_budget", NA, "2017-2022", NA, "aneel_cde_$year$",
     "aneel", "energy_generation", NA, "1908-2021", "Municipality", "https://git.aneel.gov.br/publico/centralconteudo/-/raw/main/relatorioseindicadores/geracao/BD_SIGA.xlsx?inline=false",
     "aneel", "energy_enterprises_distributed", NA, NA, NA, "https://dadosabertos.aneel.gov.br/dataset/5e0fafd2-21b9-4d5b-b622-40438d40aba2/resource/b1bd71e7-d0ad-4214-9053-cbd58e9564a7/download/empreendimento-geracao-distribuida.csv",
 

--- a/R/download.R
+++ b/R/download.R
@@ -333,6 +333,28 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
 
   path <- param$url
 
+  
+  if (identical(path, "aneel_cde_$year$")) {
+    cde_urls <- c(
+      "2017" = "URL_DO_2017",
+      "2018" = "URL_DO_2018",
+      "2019" = "URL_DO_2019",
+      "2020" = "URL_DO_2020",
+      "2021" = "URL_DO_2021",
+      "2022" = "URL_DO_2022"
+    )
+    
+    if (is.null(param$year)) {
+      stop("For 'energy_development_budget', please provide 'year'.")
+    }
+    
+    if (!as.character(param$year) %in% names(cde_urls)) {
+      stop("Year not available for 'energy_development_budget'.")
+    }
+    
+    path <- unname(cde_urls[as.character(param$year)])
+  }
+  
   ## Filling in URLs
 
   # Some URLs are in the form www.data/$year$_$dataset$.csv, where expression
@@ -464,7 +486,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   }
   if (source == "aneel") {
     if (dataset == "energy_development_budget") {
-      file_extension <- ".rds"
+      file_extension <- ".csv"
     }
     if (dataset == "energy_generation") {
       file_extension <- ".xlsx"
@@ -487,9 +509,6 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
     download_method <- "googledrive"
   }
   if (source == "aneel") {
-    if (dataset == "energy_development_budget") {
-      download_method <- "googledrive"
-    }
     if (dataset == "energy_enterprises_distributed") {
       message("This may take a while.\n")
       options(timeout = 1000) # increase timeout limit
@@ -599,9 +618,17 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   }
 
   if (param$source == "aneel") {
-    if (param$dataset == "energy_enterprises_distributed") {
+    if (param$dataset %in% c("energy_enterprises_distributed", "energy_development_budget")) {
       dat <- data.table::fread(temp, encoding = "Latin-1")
-    } else if (dataset == "energy_generation") {
+    } else if (param$dataset == "energy_generation") {
+      dat <- readxl::read_xlsx(
+        temp,
+        sheet = param$sheet,
+        skip = param$skip_rows,
+        na = c("-", "")
+      )
+    }
+  } else if (dataset == "energy_generation") {
       dat <- readxl::read_xlsx(temp, sheet = param$sheet, skip = param$skip_rows, na = c("-", ""))
     }
   } else if (param$source == "ips") {
@@ -898,7 +925,7 @@ datasets_link <- function(source = NULL, dataset = NULL, url = FALSE) {
 
     ## ANEEL
 
-    "aneel", "energy_development_budget", NA, "2013-2022", NA, "https://drive.google.com/file/d/1h7mu-9qbKfISk1-k4JSrBhXKBMQHTOH9/view?usp=share_link",
+    "aneel", "energy_development_budget", NA, "2013-2022", NA, "aneel_cde_$year$",
     "aneel", "energy_generation", NA, "1908-2021", "Municipality", "https://git.aneel.gov.br/publico/centralconteudo/-/raw/main/relatorioseindicadores/geracao/BD_SIGA.xlsx?inline=false",
     "aneel", "energy_enterprises_distributed", NA, NA, NA, "https://dadosabertos.aneel.gov.br/dataset/5e0fafd2-21b9-4d5b-b622-40438d40aba2/resource/b1bd71e7-d0ad-4214-9053-cbd58e9564a7/download/empreendimento-geracao-distribuida.csv",
 

--- a/R/download.R
+++ b/R/download.R
@@ -583,63 +583,64 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
     if (param$source == "sigmine") {
       dat <- purrr::quietly(sf::read_sf)(file.path(dir, "BRASIL.shp"))$result
     }
-
     if (param$source == "ibama") {
       shp <- list.files(dir, pattern = "\\.shp$", full.names = TRUE, recursive = TRUE)
       dat_sf <- sf::read_sf(shp[1], quiet = TRUE)
       dat <- tibble::as_tibble(dat_sf)
     }
-
     if (param$source == "baci") {
       # as year can be a vector, sets up expressions of the form "*YYYY_V202401b.csv" for each year to match file names
       file_expression <- paste0("*", param$year, "_V202401b.csv")
-
       # now turning into *XXXX_V202401b.csv|YYYY_V202401b.csv|ZZZZ_V202401b.csv" to match as regex
       file_expression <- paste0(file_expression, collapse = "|")
-
+      
       file <- list.files(dir, pattern = file_expression, full.names = TRUE) %>%
         as.list()
-
+      
       # now reads each file
+      
       dat <- lapply(file, data.table::fread, header = TRUE, sep = ",")
-
+      
       # each data frame in the list is named after the corresponding year
       names(dat) <- param$year
     }
     if (param$source == "prodes") {
       # clearing rasters to avoid overlap
-
+      
       terra::tmpFiles(remove = TRUE)
-
       file <- list.files(dir, pattern = "*.tif", full.names = TRUE)
-
       dat <- terra::rast(file)
     }
-  }
-
-if (param$source == "aneel") {
-  if (param$dataset %in% c("energy_enterprises_distributed", "energy_development_budget")) {
-    dat <- data.table::fread(temp, encoding = "Latin-1")
-  } } else if (dataset == "energy_generation") {
-      dat <- readxl::read_xlsx(temp, sheet = param$sheet, skip = param$skip_rows, na = c("-", ""))
+    
+  } else if (param$source == "aneel") {
+    if (param$dataset %in% c("energy_enterprises_distributed", "energy_development_budget")) {
+      dat <- data.table::fread(temp, encoding = "Latin-1")
+    } else if (param$dataset == "energy_generation") {
+      dat <- readxl::read_xlsx(
+        temp,
+        sheet = param$sheet,
+        skip = param$skip_rows,
+        na = c("-", "")
+      )
     }
+    
   } else if (param$source == "ips") {
     dat <- param$sheet %>%
       purrr::map(
         ~ readxl::read_xlsx(temp, sheet = .)
       )
+    
   } else if (param$source == "epe") {
     dat <- param$sheet %>%
       purrr::map(
         ~ base::suppressMessages(readxl::read_xlsx(temp, sheet = .))
       )
-  }
-
-  ## Now the rest of the functions
-
-  # This Depends on Data Type (.csv, .shp, ...) and on the data source
-
-  else {
+    
+    ## Now the rest of the functions
+    
+    # This Depends on Data Type (.csv, .shp, ...) and on the data source
+    
+  } else {
     if (file_extension == ".csv") {
       dat <- data.table::fread(temp)
     }
@@ -653,10 +654,12 @@ if (param$source == "aneel") {
       dat <- readr::read_rds(temp)
     }
     if (file_extension == ".xlsx") {
-      dat <-
-        readxl::read_xlsx(temp, sheet = param$sheet, skip = param$skip_rows)
+      dat <- readxl::read_xlsx(temp, sheet = param$sheet, skip = param$skip_rows)
     }
   }
+  
+
+
 
   ##############################
   ## Excluding Temporary File ##

--- a/R/download.R
+++ b/R/download.R
@@ -617,18 +617,10 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
     }
   }
 
-  if (param$source == "aneel") {
-    if (param$dataset %in% c("energy_enterprises_distributed", "energy_development_budget")) {
-      dat <- data.table::fread(temp, encoding = "Latin-1")
-    } else if (param$dataset == "energy_generation") {
-      dat <- readxl::read_xlsx(
-        temp,
-        sheet = param$sheet,
-        skip = param$skip_rows,
-        na = c("-", "")
-      )
-    }
-  } else if (dataset == "energy_generation") {
+if (param$source == "aneel") {
+  if (param$dataset %in% c("energy_enterprises_distributed", "energy_development_budget")) {
+    dat <- data.table::fread(temp, encoding = "Latin-1")
+  } } else if (dataset == "energy_generation") {
       dat <- readxl::read_xlsx(temp, sheet = param$sheet, skip = param$skip_rows, na = c("-", ""))
     }
   } else if (param$source == "ips") {

--- a/R/download.R
+++ b/R/download.R
@@ -336,12 +336,12 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
   
   if (identical(path, "aneel_cde_$year$")) {
     cde_urls <- c(
-      "2017" = "URL_DO_2017",
-      "2018" = "URL_DO_2018",
-      "2019" = "URL_DO_2019",
-      "2020" = "URL_DO_2020",
-      "2021" = "URL_DO_2021",
-      "2022" = "URL_DO_2022"
+      "2017" = "https://dadosabertos.aneel.gov.br/dataset/a7191647-b187-4893-b20a-8954d57ff89c/resource/684a68fd-4278-4af1-bcf2-c02810dd7c0c/download/cde-beneficiarios-rede-basica-2017.csv",
+      "2018" = "https://dadosabertos.aneel.gov.br/dataset/a7191647-b187-4893-b20a-8954d57ff89c/resource/237f3f67-4795-4bd7-a4d2-5f6071ef39af/download/cde-beneficiarios-rede-basica-2018.csv",
+      "2019" = "https://dadosabertos.aneel.gov.br/dataset/a7191647-b187-4893-b20a-8954d57ff89c/resource/0bd1f129-39c5-4edc-b272-3f1d11181cca/download/cde-beneficiarios-rede-basica-2019.csv",
+      "2020" = "https://dadosabertos.aneel.gov.br/dataset/a7191647-b187-4893-b20a-8954d57ff89c/resource/f77bb713-cc06-406a-baa8-246acc357ff5/download/cde-beneficiarios-rede-basica-2020.csv",
+      "2021" = "https://dadosabertos.aneel.gov.br/dataset/a7191647-b187-4893-b20a-8954d57ff89c/resource/cdf1b068-7c76-462a-ab57-d6619ad290fa/download/cde-beneficiarios-rede-basica-2021.csv",
+      "2022" = "https://dadosabertos.aneel.gov.br/dataset/a7191647-b187-4893-b20a-8954d57ff89c/resource/e390baae-5304-4a94-854f-0905094b3357/download/cde-beneficiarios-rede-basica-2022.csv"
     )
     
     if (is.null(param$year)) {

--- a/README.md
+++ b/README.md
@@ -1448,7 +1448,17 @@ and select “Dicionário de dados”.
     - `FALSE`: if you want the treated version of the data.
 3.  **language**: you can choose between Portuguese `("pt")` and English
     `("eng")`
-
+4.  **year**: this parameter is specifically applicable to the dataset
+      `"energy_development_budget"`. It allows the user to select a 
+      particular year, enabling a defined temporal subset of the data.
+      For the remaining datasets, this parameter should be set to `"NULL"`.
+      The available year options are:
+      - `2017`
+      - `2018`
+      - `2019`
+      - `2020`
+      - `2021`
+      - `2022`
 ------------------------------------------------------------------------
 
 **Examples:**
@@ -1459,6 +1469,16 @@ clean_aneel <- load_aneel(
   dataset = "energy_generation",
   raw_data = FALSE
 )
+```
+
+```r
+
+development_budget_aneel = load_aneel(
+  dataset = "energy_development_budget",
+  raw_data = TRUE,
+  year = c(2020,2021)
+)
+
 ```
 
 ## EPE

--- a/README.md
+++ b/README.md
@@ -1380,18 +1380,21 @@ Electrical Energy Market to develop with balance and for the benefit of
 society.
 
 As for now, there are three different datasets available for download:
-the Energy Development Budget and the Energy Generation.
+Energy Development Budget, Energy Generation, and Energy Enterprises
+Distributed.
 
 #### Energy Development Budget
 
 The Energy Development Budget dataset showcases the Energy Development
-Account’s (CDE) anual budget expenses. The CDE is designed to promote
+Account’s (CDE) annual budget expenses. The CDE is designed to promote
 the Brazilian energy development and is managed by the Electrical Energy
 Commercialization Chamber (CCEE).
 
-The dataset makes available the year of the observation – from 2013 to
-2022 –, the type of expense, its value in R\$ (Reais) and its share over
-the total amount of CDE budget expenses on the year\*.
+In the current implementation, data is available from 2017 to 2022 and
+must be downloaded by year. The year argument can be a single year or a
+vector of years. The dataset includes the type of expense, its value in
+R\$ (Reais), and its share over the total amount of CDE budget expenses
+in each year.\*.
 
 \*Note that ‘share_of_total’ values sum to 1 for each year available.
 
@@ -1448,17 +1451,11 @@ and select “Dicionário de dados”.
     - `FALSE`: if you want the treated version of the data.
 3.  **language**: you can choose between Portuguese `("pt")` and English
     `("eng")`
-4.  **year**: this parameter is specifically applicable to the dataset
-      `"energy_development_budget"`. It allows the user to select a 
-      particular year, enabling a defined temporal subset of the data.
-      For the remaining datasets, this parameter should be set to `"NULL"`.
-      The available year options are:
-      - `2017`
-      - `2018`
-      - `2019`
-      - `2020`
-      - `2021`
-      - `2022`
+4.  **year**: only used for “energy_development_budget”. It can be a
+    single year or a vector of years from 2017:2022. This argument is
+    required for “energy_development_budget” and can be omitted for the
+    other datasets.
+
 ------------------------------------------------------------------------
 
 **Examples:**
@@ -1469,16 +1466,21 @@ clean_aneel <- load_aneel(
   dataset = "energy_generation",
   raw_data = FALSE
 )
-```
 
-```r
 
-development_budget_aneel = load_aneel(
+# download raw CDE data for one year
+budget_aneel_2019 <- load_aneel(
   dataset = "energy_development_budget",
   raw_data = TRUE,
-  year = c(2020,2021)
+  year = 2019
 )
 
+# download raw CDE data for multiple years
+budget_aneel_multi <- load_aneel(
+  dataset = "energy_development_budget",
+  raw_data = TRUE,
+  year = c(2020, 2021)
+)
 ```
 
 ## EPE

--- a/README.md
+++ b/README.md
@@ -1456,7 +1456,7 @@ and select “Dicionário de dados”.
 ``` r
 # download treated data about energy generation
 clean_aneel <- load_aneel(
-  dataset = "energy generation",
+  dataset = "energy_generation",
   raw_data = FALSE
 )
 ```

--- a/man/load_aneel.Rd
+++ b/man/load_aneel.Rd
@@ -4,7 +4,7 @@
 \alias{load_aneel}
 \title{ANEEL}
 \usage{
-load_aneel(dataset, raw_data = FALSE, language = "eng")
+load_aneel(dataset, raw_data = FALSE, language = "eng", year = NULL)
 }
 \arguments{
 \item{dataset}{A dataset name ("energy_development_budget", "energy_generation" or "energy_enterprises_distributed")}
@@ -12,6 +12,10 @@ load_aneel(dataset, raw_data = FALSE, language = "eng")
 \item{raw_data}{A \code{boolean} setting the return of raw (\code{TRUE}) or processed (\code{FALSE}) data.}
 
 \item{language}{A \code{string} that indicates in which language the data will be returned. Portuguese ("pt") and English ("eng") are supported.}
+
+\item{year}{A numeric value or vector of years (2017-2022).
+Required for the "energy_development_budget" dataset.
+Ignored for the other datasets.}
 }
 \description{
 National Electric Energy Agency - ANEEL
@@ -22,6 +26,13 @@ National Electric Energy Agency - ANEEL
 clean_aneel <- load_aneel(
   dataset = "energy_generation",
   raw_data = FALSE
+)
+
+# download raw annual CDE budget data
+raw_cde <- load_aneel(
+  dataset = "energy_development_budget",
+  year = 2021,
+  raw_data = TRUE
 )
 }
 

--- a/vignettes/ANEEL.Rmd
+++ b/vignettes/ANEEL.Rmd
@@ -16,13 +16,14 @@ knitr::opts_chunk$set(
 
 Loads data from the National Electrical Energy Agency (ANEEL), a Brazilian independent federal agency linked to the Ministry of Mines and Energy (MME). ANEEL works to provide favorable conditions for the Electrical Energy Market to develop with balance and for the benefit of society.
 
-As for now, there are three different datasets available for download: the Energy Development Budget and the Energy Generation.
+As for now, there are three different datasets available for download: Energy Development Budget, Energy Generation, and Energy Enterprises Distributed.
 
 #### Energy Development Budget
 
-The Energy Development Budget dataset showcases the Energy Development Account's (CDE) anual budget expenses. The CDE is designed to promote the Brazilian energy development and is managed by the Electrical Energy Commercialization Chamber (CCEE).
+The Energy Development Budget dataset showcases the Energy Development Account's (CDE) annual budget expenses. The CDE is designed to promote the Brazilian energy development and is managed by the Electrical Energy Commercialization Chamber (CCEE).
 
-The dataset makes available the year of the observation -- from 2013 to 2022 --, the type of expense, its value in R$ (Reais) and its share over the total amount of CDE budget expenses on the year\*.
+In the current implementation, data is available from 2017 to 2022 and must be downloaded by year. The year argument can be a single year or a vector of years.
+The dataset includes the type of expense, its value in R$ (Reais), and its share over the total amount of CDE budget expenses in each year.\*.
 
 \*Note that 'share_of_total' values sum to 1 for each year available.
 
@@ -55,6 +56,10 @@ The data is expressed in quantities and installed power in kW (kilowatt). The qu
       * `FALSE`: if you want the treated version of the data. 
 
   3. **language**: you can choose between Portuguese `("pt")` and English `("eng")`
+  4. **year**: only used for "energy_development_budget".
+It can be a single year or a vector of years from 2017:2022.
+This argument is required for "energy_development_budget" and can be
+omitted for the other datasets.
   
 ***
 
@@ -63,7 +68,22 @@ The data is expressed in quantities and installed power in kW (kilowatt). The qu
 ```{r eval=FALSE}
 # download treated data about energy generation
 clean_aneel <- load_aneel(
-  dataset = "energy generation",
+  dataset = "energy_generation",
   raw_data = FALSE
+)
+
+
+# download raw CDE data for one year
+budget_aneel_2019 <- load_aneel(
+  dataset = "energy_development_budget",
+  raw_data = TRUE,
+  year = 2019
+)
+
+# download raw CDE data for multiple years
+budget_aneel_multi <- load_aneel(
+  dataset = "energy_development_budget",
+  raw_data = TRUE,
+  year = c(2020, 2021)
 )
 ```


### PR DESCRIPTION
A new parameter (year = NULL) has been added to the load_aneel function. This parameter is required for the energy_development_budget dataset, which contains separate files for each year between 2017 and 2022.

The download is now performed directly from the ANEEL website via the following link: https://dadosabertos.aneel.gov.br/dataset/beneficiarios-da-cde

Solves #312 

Note: The changes have already been tested and are fully functional.