### PR TITLE
Fix: Update TerraClimate THREDDS URL to resolve GDAL error in load_climate()

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -398,7 +398,7 @@ external_download <- function(dataset = NULL, source = NULL, year = NULL,
     filename <- paste0(
       "agg_terraclimate_",
       param$dataset_code,
-      "_1958_CurrentYear_GLOBE.nc"
+      "_1950_CurrentYear_GLOBE.nc"
     )
 
     path <- paste0(


### PR DESCRIPTION
**Description:**
This PR fixes a critical bug in the `load_climate()` function caused by a recent update to the TerraClimate THREDDS catalog.

The upstream server changed the base year for their aggregated NetCDF files from 1958 to 1950. Because the package was still requesting the old file pattern (`agg_terraclimate_*_1958_CurrentYear_GLOBE.nc`), the download was failing silently (resulting in a 0-byte file). Consequently, when `terra::rast()` attempted to read the empty `.nc` file, it triggered the following error:

> `not recognized as being in a supported file format. (GDAL error 4)`

**Change:**

* Updated the URL string in the download function (e.g., `external_download()`) to target the new file naming convention: `agg_terraclimate_*_1950_CurrentYear_GLOBE.nc`.

fixed #335 